### PR TITLE
Refactor: Conjunctions

### DIFF
--- a/src/api/interestedSatellites/interestedSatellites.task.js
+++ b/src/api/interestedSatellites/interestedSatellites.task.js
@@ -2,69 +2,83 @@
 /* eslint-disable no-console */
 const moment = require('moment');
 const InterestedSatellitesService = require('./interestedSatellites.service');
+const PpdbService = require('../ppdbs/ppdb.service');
 const SendEmailHandler = require('../../lib/node-mailer');
-const InterestedSatellitesHandler = require('../../lib/interestedSatellites-handler');
+const MailingServiceHandler = require('../../lib/mailingService-handler');
 
 class InterestedSatellitesTask {
   /**
    * @param { InterestedSatellitesService } InterestedSatellitesService
+   * @param { PpdbService } ppdbService
    */
-  constructor(interestedSatellitesService) {
+  constructor(interestedSatellitesService, ppdbService) {
     this.name = 'IS TASK';
     this.period = '0 0 0 * * *';
     this.interestedSatellitesService = interestedSatellitesService;
+    this.ppdbService = ppdbService;
     this.handler = this.#sendInterestedConjunctions.bind(this);
   }
 
   async #sendInterestedConjunctions() {
-    const users = await this.interestedSatellitesService.getSubscribingUsers();
+    const users = await this.interestedSatellitesService.readSubscribingUsers();
     await Promise.all(
       users.map(async (user) => {
         const { email, interestedArray } = user;
         if (interestedArray.length == 0) return;
         const satellitesIds = interestedArray.map((satellite) => satellite.id);
-        const conjunctionsByDca =
-          await this.interestedSatellitesService.getConjunctionsByDca(
+        const conjunctionsForHtml =
+          await this.ppdbService.findConjunctionsByIdsService(
+            10,
+            0,
+            'dca',
             satellitesIds,
+            false,
           );
-        const conjunctionsBySatellitesIds =
-          await this.interestedSatellitesService.getConjunctionsBySatellitesIds(
-            satellitesIds,
-          );
-        const metadata = this.interestedSatellitesService.getMetadata(
-          conjunctionsBySatellitesIds,
+        const conjunctionsForCsv = await Promise.all(
+          satellitesIds.map(async (satelliteId) =>
+            this.ppdbService.findConjunctionsByIdsService(
+              0,
+              0,
+              'tcaTime',
+              [satelliteId],
+              false,
+            ),
+          ),
         );
+        const metadata = interestedArray.map((object, index) => {
+          return {
+            id: object.id,
+            name: object.name,
+            numConjunctions: conjunctionsForCsv[index].totalcount,
+          };
+        });
 
         await SendEmailHandler.sendMail(
           email,
           `[SPACEMAP] Daily Conjunctions Report : ${moment
             .utc()
             .format('MMM DD')}`,
-          InterestedSatellitesHandler.conjunctionsToHtml(
-            conjunctionsByDca,
+          await MailingServiceHandler.conjunctionsToHtml(
+            conjunctionsForHtml,
             metadata,
           ),
-          await InterestedSatellitesHandler.conjunctionsToAttachment(
-            conjunctionsBySatellitesIds,
+          await MailingServiceHandler.conjunctionsToAttachment(
+            conjunctionsForCsv,
+            metadata,
             email,
           ),
         );
       }),
     );
 
-    InterestedSatellitesHandler.removeAllZips();
+    MailingServiceHandler.removeAllZips();
   }
 }
 
 module.exports = InterestedSatellitesTask;
 
 /* ISSUES
- * platform primary 정렬
  * forEach, map ??
- * insertMany가 바로 적용 안되는 현상?
- * conjunctions[i][0]이 없는 경우 있을까?
- * public/zips
  * .exec()
- * gitignore, package.json 수정됐음
  * subscrive는 왜 __v 밑에?
  */

--- a/src/api/ppdbs/ppdb.controller.js
+++ b/src/api/ppdbs/ppdb.controller.js
@@ -20,13 +20,8 @@ class PpdbController {
   }
 
   async findConjunctions(req, _res) {
-    let {
-      limit = 10,
-      page = 0,
-      sort = 'tcaTime',
-      dec = '',
-      satellite,
-    } = req.query;
+    let { limit = 10, page = 0, sort = 'tcaTime', dec = '' } = req.query;
+    const { satellite } = req.query;
 
     if (page < 0) {
       page = 0;
@@ -41,20 +36,14 @@ class PpdbController {
       dec = '';
     }
     sort = `${dec}${sort}`;
-    if (satellite) {
-      satellite = satellite.toUpperCase();
-    }
 
     if (satellite) {
       const { conjunctions, totalcount } = await (StringHandler.isNumeric(
         satellite,
       )
-        ? this.ppdbService.findConjunctionsByIdService(
-            limit,
-            page,
-            sort,
+        ? this.ppdbService.findConjunctionsByIdsService(limit, page, sort, [
             satellite,
-          )
+          ])
         : this.ppdbService.findConjunctionsByNameService(
             limit,
             page,

--- a/src/api/ppdbs/ppdb.service.js
+++ b/src/api/ppdbs/ppdb.service.js
@@ -38,9 +38,9 @@ class PpdbService {
     };
     const totalcount = await PpdbModel.countDocuments(queryOption).exec();
     const conjunctions = await PpdbModel.find(queryOption)
+      .sort(sort)
       .skip(limit * page)
       .limit(limit)
-      .sort(sort)
       .exec();
     return {
       totalcount,
@@ -48,19 +48,28 @@ class PpdbService {
     };
   }
 
-  async findConjunctionsByIdService(limit, page, sort, id) {
+  async findConjunctionsByIdsService(limit, page, sort, ids, future = true) {
     const queryOption = {
       $and: [
-        { $or: [{ pid: id }, { sid: id }] },
-        { tcaTime: { $gte: new Date() } },
+        { $or: [{ pid: { $in: ids } }, { sid: { $in: ids } }] },
+        future ? { tcaTime: { $gte: new Date() } } : {},
       ],
     };
     const totalcount = await PpdbModel.countDocuments(queryOption).exec();
     const conjunctions = await PpdbModel.find(queryOption)
+      .sort(sort)
       .skip(limit * page)
       .limit(limit)
-      .sort(sort)
       .exec();
+    conjunctions.map((conjunction) => {
+      if (ids.some((id) => id == conjunction.sid)) {
+        [conjunction.pid, conjunction.sid] = [conjunction.sid, conjunction.pid];
+        [conjunction.pName, conjunction.sName] = [
+          conjunction.sName,
+          conjunction.pName,
+        ];
+      }
+    });
     return {
       totalcount,
       conjunctions,
@@ -81,10 +90,19 @@ class PpdbService {
     };
     const totalcount = await PpdbModel.countDocuments(queryOption).exec();
     const conjunctions = await PpdbModel.find(queryOption)
+      .sort(sort)
       .skip(limit * page)
       .limit(limit)
-      .sort(sort)
       .exec();
+    conjunctions.map((conjunction) => {
+      if (new RegExp(name, 'i').test(conjunction.sName)) {
+        [conjunction.pid, conjunction.sid] = [conjunction.sid, conjunction.pid];
+        [conjunction.pName, conjunction.sName] = [
+          conjunction.sName,
+          conjunction.pName,
+        ];
+      }
+    });
     return {
       totalcount,
       conjunctions,

--- a/src/server.js
+++ b/src/server.js
@@ -77,6 +77,7 @@ const main = async () => {
   );
   const interestedSatellitesTask = new InterestedSatellitesTask(
     interestedSatellitesService,
+    ppdbService,
   );
 
   const watcherCatchersTask = new WatcherCatchersTask(
@@ -105,7 +106,10 @@ const main = async () => {
     const app = new App([
       new TleController(tleService),
       new PpdbController(ppdbService),
-      new InterestedSatellitesController(interestedSatellitesService),
+      new InterestedSatellitesController(
+        interestedSatellitesService,
+        ppdbService,
+      ),
       new LaunchConjunctionsController(launchConjunctionsService),
       new WatcherCatchersController(watcherCatchersService),
       new OauthController(),


### PR DESCRIPTION
* 모든 conjunctions 처리는 ppdbServices에서
* 1. findConjunctionsService : 모든 conjunction
* 2. findConjunctionsByIdsService : 해당 id에 해당하는 conjunction (*** id가 1개라도 배열로 입력)
* 3. findConjunctionsByNameService: 해당 name에 해당하는 conjunction (대소문자 구별 X)
*
* 검색하려는 id 또는 name에 해당하는 satellite가 primary의 위치에 감 (interestedSatellites 포함)
* tcaTime이 현재 시각 이전인 conjunction은 무시
* 단, future=false로 입력할 시, 현재 시각 이전인 conjunction 포함 (메일링 서비스)
*
* conjunctions 처리 외의 html, csv, zip 등은 모두 mailingServiceHandler에서